### PR TITLE
fix: use correct kernel module name libwolfssl in modulesLoadingOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ To enable transparent, end-to-end volume encryption using a KMIP provider:
         # Insert the full KMIP client configuration file content here.
         # This typically includes server addresses, port, and client TLS/PKI settings.
     ```
-3. Make sure KMM module is configured to load `wolfssl` kermel module. Check this:
+3. Make sure KMM module is configured to load `libwolfssl` kernel module. Check this:
     ```bash
     kubectl get module panfs -n csi-panfs -o jsonpath='{.spec.moduleLoader.container.modprobe.modulesLoadingOrder}'
-    ["panfs","wolfssl"]
+    ["panfs","libwolfssl"]
     ```
 
 ##### 3.4 Deployment and Validation

--- a/charts/panfs/templates/kmm-module.yml
+++ b/charts/panfs/templates/kmm-module.yml
@@ -67,18 +67,18 @@ spec:
 
         {{- if .Values.kmm.encryptionSupport }}
 
-        # Encryption support requires loading the wolfssl module.
-        # If encryption is not needed or, comment out the modulesLoadingOrder below.
+        # Encryption support requires loading the libwolfssl module.
+        # If encryption is not needed, comment out the modulesLoadingOrder below.
         modulesLoadingOrder: 
           - panfs
-          - wolfssl
+          - libwolfssl
         {{- else }}
 
-        # If encryption support is required, load the wolfssl module before panfs.
+        # If encryption support is required, load the libwolfssl module before panfs.
         # To enable encryption, uncomment and set modulesLoadingOrder as shown below.
         # modulesLoadingOrder: 
         #  - panfs
-        #  - wolfssl
+        #  - libwolfssl
         {{- end }}
 
       imagePullPolicy: {{ .Values.kmm.pullPolicy | default "Always" }}

--- a/deploy/k8s/Readme.md
+++ b/deploy/k8s/Readme.md
@@ -88,10 +88,10 @@ To enable transparent, end-to-end volume encryption using a KMIP provider:
         # Insert the full KMIP client configuration file content here.
         # This typically includes server addresses, port, and client TLS/PKI settings.
     ```
-3. Make sure KMM module is configured to load `wolfssl` kermel module. Check this:
+3. Make sure KMM module is configured to load `libwolfssl` kernel module. Check this:
     ```bash
     kubectl get module panfs -n csi-panfs -o jsonpath='{.spec.moduleLoader.container.modprobe.modulesLoadingOrder}'
-    ["panfs","wolfssl"]
+    ["panfs","libwolfssl"]
     ```
 
 ## 4. Example: Creating a PersistentVolumeClaim (PVC)

--- a/deploy/k8s/csi-driver/example-csi-panfs.yaml
+++ b/deploy/k8s/csi-driver/example-csi-panfs.yaml
@@ -908,11 +908,11 @@ spec:
       modprobe:
         moduleName: panfs
 
-        # Encryption support requires loading the wolfssl module.
-        # If encryption is not needed or, comment out the modulesLoadingOrder below.
+        # Encryption support requires loading the libwolfssl module.
+        # If encryption is not needed, comment out the modulesLoadingOrder below.
         modulesLoadingOrder: 
           - panfs
-          - wolfssl
+          - libwolfssl
 
       imagePullPolicy: Always
 

--- a/deploy/k8s/csi-driver/template-csi-panfs-with-e2ee.yaml
+++ b/deploy/k8s/csi-driver/template-csi-panfs-with-e2ee.yaml
@@ -908,11 +908,11 @@ spec:
       modprobe:
         moduleName: panfs
 
-        # Encryption support requires loading the wolfssl module.
-        # If encryption is not needed or, comment out the modulesLoadingOrder below.
+        # Encryption support requires loading the libwolfssl module.
+        # If encryption is not needed, comment out the modulesLoadingOrder below.
         modulesLoadingOrder: 
           - panfs
-          - wolfssl
+          - libwolfssl
 
       imagePullPolicy: Always
 

--- a/deploy/k8s/csi-driver/template-csi-panfs-without-selinux.yaml
+++ b/deploy/k8s/csi-driver/template-csi-panfs-without-selinux.yaml
@@ -874,11 +874,11 @@ spec:
       modprobe:
         moduleName: panfs
 
-        # Encryption support requires loading the wolfssl module.
-        # If encryption is not needed or, comment out the modulesLoadingOrder below.
+        # Encryption support requires loading the libwolfssl module.
+        # If encryption is not needed, comment out the modulesLoadingOrder below.
         modulesLoadingOrder: 
           - panfs
-          - wolfssl
+          - libwolfssl
 
       imagePullPolicy: Always
 

--- a/deploy/k8s/csi-driver/template-csi-panfs.yaml
+++ b/deploy/k8s/csi-driver/template-csi-panfs.yaml
@@ -925,11 +925,11 @@ spec:
       modprobe:
         moduleName: panfs
 
-        # Encryption support requires loading the wolfssl module.
-        # If encryption is not needed or, comment out the modulesLoadingOrder below.
+        # Encryption support requires loading the libwolfssl module.
+        # If encryption is not needed, comment out the modulesLoadingOrder below.
         modulesLoadingOrder: 
           - panfs
-          - wolfssl
+          - libwolfssl
 
       imagePullPolicy: Always
 

--- a/docs/Encryption.md
+++ b/docs/Encryption.md
@@ -11,7 +11,7 @@ To use volume encryption, you must meet the following requirements:
 
 ## 1. Enable Encryption in CSI Driver
 
-When installing or upgrading the PanFS CSI driver via Helm, encryption support should be enabled. This allows the driver to load necessary encryption modules (e.g. `wolfssl`) on the worker nodes.
+When installing or upgrading the PanFS CSI driver via Helm, encryption support should be enabled. This allows the driver to load necessary encryption modules (e.g. `libwolfssl`) on the worker nodes.
 
 Encryption support is enabled by default via the `kmm.encryptionSupport` parameter. To explicitly ensure it is enabled during installation:
 


### PR DESCRIPTION
## Summary

The panfs-kmm image ships `libwolfssl.ko` (in-kernel name `libwolfssl`, confirmed via dmesg `libwolfssl: loading out-of-tree module` and the image contents), but the Module CR declared `modulesLoadingOrder: [panfs, wolfssl]`.

- **Loading** worked despite the wrong name: modprobe resolves `libwolfssl` through `modules.dep` as a dependency of `panfs.ko`, and the `modulesLoadingOrder` entry is only used as a softdep hint.
- **Unloading** did not: the KMM unload worker passes the list verbatim (`modprobe -rvd /tmp/opt panfs wolfssl`), which fails with `FATAL: Module wolfssl not found` and crashloops forever. This deadlocks KMM's NodeModulesConfig reconciliation — the module stays unloaded, KMM never creates a load worker, and every panfs mount on the node fails with `mount.panfs: panfs is not configured in the kernel`.

Observed trigger in CI: a node going briefly NotReady (kubelet restart in the k8s e2e `[Disruptive]` storage tests) causes KMM to schedule an unload, which then wedges permanently.

## Changes

- Renamed the `modulesLoadingOrder` entry `wolfssl` → `libwolfssl` in all four deploy manifests (`template-csi-panfs.yaml`, `template-csi-panfs-with-e2ee.yaml`, `template-csi-panfs-without-selinux.yaml`, `example-csi-panfs.yaml`) and in the Helm chart (`charts/panfs/templates/kmm-module.yml`, both the active list and the commented-out example). `moduleName: panfs` is untouched.
- Fixed the duplicated comment typo "If encryption is not needed or, comment out" → "If encryption is not needed, comment out" in the same five files.
- Updated docs to match: `README.md` and `deploy/k8s/Readme.md` (verification snippet now shows `["panfs","libwolfssl"]`, plus "kermel" → "kernel" typo) and `docs/Encryption.md`.

No remaining bare `wolfssl` references in the repo — all matches referred to the kernel module name, none to the wolfSSL project by brand.

## Validation

- All four deploy manifests parse cleanly as multi-document YAML.
- The Helm template edit touches only comment text and literal list items — no Go-template syntax changed.
- No Go code touched, so unit tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)