### PR TITLE
fix(ci): use v-prefixed tag for aquasecurity/trivy-action

### DIFF
--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.32.0
         with:
           scan-type: 'fs'
           format: 'github'


### PR DESCRIPTION
## Description

The **Vulnerability Scan** workflow fails on the `trivy-generate-sbom` job with:

```
Unable to resolve action `aquasecurity/trivy-action@0.32.0`, unable to find version `0.32.0`
```

The `aquasecurity/trivy-action` repository only publishes `v`-prefixed release tags (`v0.32.0`, `v0.33.0`, ... `v0.36.0`) — there is no unprefixed `0.32.0` tag, so the reference cannot resolve. This PR changes the reference to `@v0.32.0`.

Note: the three other trivy-action usages (`vulnerability.yaml`, `build-reusable.yaml`, `pr.yaml`) reference `@master` and still resolve; pinning those to a release tag as well would be a reasonable follow-up for reproducibility.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified via GitHub API that `v0.32.0` exists in `aquasecurity/trivy-action` tags while `0.32.0` does not
- The fix can be confirmed by re-running the Vulnerability Scan workflow (workflow_dispatch) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)