### PR TITLE
fix(ci): bump trivy-action to v0.36.0 to fix Trivy binary installation

### DIFF
--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -18,6 +18,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      # Validate the workflow itself when it is changed in a PR
+      - '.github/workflows/vulnerability.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@v0.32.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           format: 'github'


### PR DESCRIPTION
## Description

Follow-up to #13. The tag now resolves, but the `trivy-generate-sbom` job still fails — one step later, inside `setup-trivy`:

```
aquasecurity/trivy info checking GitHub for tag 'v0.64.1'
aquasecurity/trivy info found version: 0.64.1 for v0.64.1/Linux/64bit
Error: Process completed with exit code 1.
```

**Root cause:** `trivy-action@v0.32.0` pins Trivy **v0.64.1** as its default binary version, but `setup-trivy` installs it using `contrib/install.sh` checked out from the trivy repo's **main branch**. That current-script + old-binary combination fails during installation. Evidence: in the same run, the `trivy-scan` job using `trivy-action@master` (which installs a current Trivy) **succeeded**, while the SBOM job failed.

**Fix:** bump both jobs in `vulnerability.yaml` to the latest release `aquasecurity/trivy-action@v0.36.0`, which pins a current Trivy version compatible with the current install script. The repo-scan job is moved from `@master` to `v0.36.0` at the same time, so both jobs are pinned and reproducible.

Note: `build-reusable.yaml` and `pr.yaml` still use `trivy-action@master`; pinning those to `v0.36.0` as well would be a reasonable follow-up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Run 28870750647 shows `trivy-scan` (@master, current Trivy) passing while `trivy-generate-sbom` (v0.32.0, Trivy v0.64.1) fails at binary install — confirming the version-pin mismatch as the cause
- Verify after merge by re-running the Vulnerability Scan workflow (workflow_dispatch)