### PR TITLE
chore: bump Helm chart versions to 1.2.5

### DIFF
--- a/charts/panfs/Chart.yaml
+++ b/charts/panfs/Chart.yaml
@@ -15,5 +15,5 @@
 apiVersion: v2
 name: csi-panfs
 description: A Helm chart for deploying VDURA PanFS CSI controller, node components, and KMM module
-version: "1.2.3"
-appVersion: "1.2.3"
+version: "1.2.5"
+appVersion: "1.2.5"

--- a/charts/panfs/Readme.md
+++ b/charts/panfs/Readme.md
@@ -3,7 +3,7 @@
 
 A Helm chart for deploying VDURA PanFS CSI controller, node components, and KMM module
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 1.2.3](https://img.shields.io/badge/AppVersion-1.2.3-informational?style=flat-square)
+![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/storageclass/Chart.yaml
+++ b/charts/storageclass/Chart.yaml
@@ -16,5 +16,5 @@
 apiVersion: v2
 name: csi-panfs-storageclass
 description: PanFS Realm Storage Class Chart
-version: "1.2.3"
-appVersion: "1.2.3"
+version: "1.2.5"
+appVersion: "1.2.5"

--- a/charts/storageclass/Readme.md
+++ b/charts/storageclass/Readme.md
@@ -18,7 +18,7 @@
 
 PanFS Realm Storage Class Chart
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 1.2.3](https://img.shields.io/badge/AppVersion-1.2.3-informational?style=flat-square)
+![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
 
 ## What PanFS CSI StorageClass is
 


### PR DESCRIPTION
## Description

Chart versions have drifted behind release tags: the repo is tagged `1.2.5`, but both `charts/panfs` and `charts/storageclass` still declare `version`/`appVersion` `1.2.3`. This bumps both charts to `1.2.5` and updates the generated Readme version badges to match.

Note: `csi.image` in `charts/panfs` defaults to `panfs-csi-driver:{{ .Chart.AppVersion }}`, so this also makes fresh chart installs pull the 1.2.5 driver image by default.

Going forward, the Create Release workflow (#15) keeps chart versions in sync automatically when cutting a release.

## Type of change

- [x] Documentation update / release chore (no functional change)

## How Has This Been Tested?

- Verified no remaining `1.2.3` references under `charts/`
- `ghcr.io/panasasinc/panfs-container-storage-interface-oss/panfs-csi-driver:1.2.5` exists (published by the Release builds workflow for the 1.2.5 tag)