### PR TITLE
ci: add monthly Dependabot checks and surface Trivy CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# Copyright 2025 VDURA Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dependabot keeps dependencies up to date and, together with Dependabot
+# security updates, opens PRs to remediate known CVEs. Version-update PRs run
+# on a monthly cadence; security updates are raised as soon as an advisory is
+# published, regardless of this schedule.
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in workflows and composite actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/tests/csi_sanity"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    groups:
+      docker-images:
+        patterns:
+          - "*"

--- a/.github/workflows/vulnerability.yaml
+++ b/.github/workflows/vulnerability.yaml
@@ -22,15 +22,24 @@ on:
     paths:
       # Validate the workflow itself when it is changed in a PR
       - '.github/workflows/vulnerability.yaml'
+  schedule:
+    # Monthly scan to discover newly disclosed CVEs in existing dependencies
+    # (03:00 UTC on the 1st of every month).
+    - cron: '0 3 1 * *'
   workflow_dispatch:
 
 jobs:
   trivy-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to upload SARIF results to the GitHub Security tab.
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Human-readable output in the workflow logs.
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -38,6 +47,23 @@ jobs:
           ignore-unfixed: true
           format: 'table'
           severity: 'HIGH,CRITICAL'
+
+      # Machine-readable output surfaced as Code scanning alerts under the
+      # repository's Security tab.
+      - name: Run Trivy vulnerability scanner (SARIF)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
 
   trivy-generate-sbom:
     permissions:


### PR DESCRIPTION
## Summary

Adds monthly dependency validation via Dependabot and improves CVE
discoverability from the existing Trivy scan.

## Changes

- **`.github/dependabot.yml` (new)** — monthly version-update checks for the
  `gomod`, `github-actions`, and `docker` ecosystems (root `Dockerfile` and
  `tests/csi_sanity/Dockerfile`). Updates are grouped per ecosystem to keep PR
  noise down. Adding this config also enables Dependabot security updates, which
  open CVE-remediation PRs as soon as an advisory is published.
- **`.github/workflows/vulnerability.yaml`** — the Trivy `fs` scan now also runs
  monthly on a schedule (catching newly disclosed CVEs in unchanged deps) and
  uploads results as SARIF to the GitHub Security / Code scanning tab, so
  findings surface as tracked alerts instead of only appearing in run logs.

## Notes

- `dfc/Dockerfile.stub` and the Helm charts are not covered — Dependabot only
  recognizes files named `Dockerfile`, and there is no ecosystem for Helm chart
  dependencies.
- **Follow-up (repo admin):** enable *Dependabot alerts* and *Dependabot
  security updates* under Settings → Code security to fully activate CVE
  detection.